### PR TITLE
.Net Core 2.1 unit tests issue.

### DIFF
--- a/src/Tests/EF.DbContextFactory.IntegrationTest.Ninject/EF.DbContextFactory.IntegrationTest.Ninject.csproj
+++ b/src/Tests/EF.DbContextFactory.IntegrationTest.Ninject/EF.DbContextFactory.IntegrationTest.Ninject.csproj
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tests/EF.DbContextFactory.IntegrationTest.SimpleInjector/EF.DbContextFactory.IntegrationTest.SimpleInjector.csproj
+++ b/src/Tests/EF.DbContextFactory.IntegrationTest.SimpleInjector/EF.DbContextFactory.IntegrationTest.SimpleInjector.csproj
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tests/EF.DbContextFactory.IntegrationTest.StructureMap/EF.DbContextFactory.IntegrationTest.StructureMap.csproj
+++ b/src/Tests/EF.DbContextFactory.IntegrationTest.StructureMap/EF.DbContextFactory.IntegrationTest.StructureMap.csproj
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tests/EF.DbContextFactory.IntegrationTest.StructureMap41.WebApi/EF.DbContextFactory.IntegrationTest.StructureMap41.WebApi.csproj
+++ b/src/Tests/EF.DbContextFactory.IntegrationTest.StructureMap41.WebApi/EF.DbContextFactory.IntegrationTest.StructureMap41.WebApi.csproj
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tests/EF.DbContextFactory.IntegrationTest.Unity/EF.DbContextFactory.IntegrationTest.Unity.csproj
+++ b/src/Tests/EF.DbContextFactory.IntegrationTest.Unity/EF.DbContextFactory.IntegrationTest.Unity.csproj
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tests/EF.DbContextFactory.UnitTest.Data/EF.DbContextFactory.UnitTest.Data.csproj
+++ b/src/Tests/EF.DbContextFactory.UnitTest.Data/EF.DbContextFactory.UnitTest.Data.csproj
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
looks like appveyor is using the new .Net Core 2.1 SDK to build the solution which brings this bug: https://github.com/dotnet/core/issues/2053