### PR TITLE
Add Options Builder Factory parameter to ServiceCollectionExtensions.

### DIFF
--- a/src/Extensions/EFCore.DbContextFactory/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Extensions/EFCore.DbContextFactory/Extensions/ServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ namespace EFCore.DbContextFactory.Extensions
         /// <param name="nameOrConnectionString">Name or connection string of the context. (Optional)</param>
         /// <param name="logger">The <see cref="ILoggerFactory"/>implementation. (Optional)</param>
         /// <param name="optionsBuilderFactory">A factory for the DbContext Options Builder. (Optional)</param>
-        public static void AddSqlServerDbContextFactory<TDataContext>(this IServiceCollection services,
+        public static IServiceCollection AddSqlServerDbContextFactory<TDataContext>(this IServiceCollection services,
             string nameOrConnectionString = null,
             ILoggerFactory logger = null,
             Func<DbContextOptionsBuilder<TDataContext>> optionsBuilderFactory = null)
@@ -35,7 +35,7 @@ namespace EFCore.DbContextFactory.Extensions
                 nameOrConnectionString = configuration.GetConnectionString("DefaultConnection");
             }
 
-            AddDbContextFactory<TDataContext>(
+            return AddDbContextFactory<TDataContext>(
                 services,
                 (provider, builder) => builder.UseSqlServer(nameOrConnectionString).UseLoggerFactory(logger),
                 optionsBuilderFactory
@@ -47,9 +47,41 @@ namespace EFCore.DbContextFactory.Extensions
         /// </summary>
         /// <typeparam name="TDataContext">The DbContext.</typeparam>
         /// <param name="services"></param>
-        /// <param name="optionsAction">The DbContext options.</param>
+        /// <param name="options">Returns the DbContext options.</param>
+        public static IServiceCollection AddDbContextFactory<TDataContext>(
+            this IServiceCollection services,
+            Func<DbContextOptions> options)
+            where TDataContext : DbContext
+            => AddDbContextFactory<TDataContext>(
+                services,
+                (provider) => options.Invoke());
+
+        /// <summary>
+        /// Configures the resolution of <typeparamref name="TDataContext"/>'s factory.
+        /// </summary>
+        /// <typeparam name="TDataContext">The DbContext.</typeparam>
+        /// <param name="services"></param>
+        /// <param name="optionsFunc">Service provider and DbContext options.</param>
+        public static IServiceCollection AddDbContextFactory<TDataContext>(
+            this IServiceCollection services,
+            Func<IServiceProvider, DbContextOptions> optionsFunc)
+            where TDataContext : DbContext
+        {
+            AddCoreServices<TDataContext>(services, optionsFunc, ServiceLifetime.Scoped);
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<DbContextOptions<TDataContext>>();
+
+            return services.AddScoped<Func<TDataContext>>(ctx => () => (TDataContext)Activator.CreateInstance(typeof(TDataContext), options));
+        }
+
+        /// <summary>
+        /// Configures the resolution of <typeparamref name="TDataContext"/>'s factory.
+        /// </summary>
+        /// <typeparam name="TDataContext">The DbContext.</typeparam>
+        /// <param name="services"></param>
+        /// <param name="optionsAction">Processes the DbContext options.</param>
         /// <param name="optionsBuilderFactory">A factory for the DbContext Options Builder. (Optional)</param>
-        public static void AddDbContextFactory<TDataContext>(this IServiceCollection services,
+        public static IServiceCollection AddDbContextFactory<TDataContext>(this IServiceCollection services,
             Action<DbContextOptionsBuilder> optionsAction,
             Func<DbContextOptionsBuilder<TDataContext>> optionsBuilderFactory = null)
             where TDataContext : DbContext
@@ -62,7 +94,7 @@ namespace EFCore.DbContextFactory.Extensions
         /// <param name="services"></param>
         /// <param name="optionsAction">Service provider and DbContext options.</param>
         /// <param name="optionsBuilderFactory">A factory for the DbContext Options Builder. (Optional)</param>
-        public static void AddDbContextFactory<TDataContext>(this IServiceCollection services,
+        public static IServiceCollection AddDbContextFactory<TDataContext>(this IServiceCollection services,
             Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
             Func<DbContextOptionsBuilder<TDataContext>> optionsBuilderFactory = null)
             where TDataContext : DbContext
@@ -71,31 +103,43 @@ namespace EFCore.DbContextFactory.Extensions
             var serviceProvider = services.BuildServiceProvider();
             var options = serviceProvider.GetService<DbContextOptions<TDataContext>>();
 
-            services.AddScoped<Func<TDataContext>>(ctx => () => (TDataContext)Activator.CreateInstance(typeof(TDataContext), options));
+            return services.AddScoped<Func<TDataContext>>(ctx => () => (TDataContext)Activator.CreateInstance(typeof(TDataContext), options));
         }
 
         private static void AddCoreServices<TContextImplementation>(
-            IServiceCollection serviceCollection,
-            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
-            Func<DbContextOptionsBuilder<TContextImplementation>> optionsBuilderFactory,
+            IServiceCollection services,
+            Func<IServiceProvider, DbContextOptions> optionsFunc,
             ServiceLifetime optionsLifetime)
             where TContextImplementation : DbContext
         {
-            serviceCollection
+            services
                 .AddMemoryCache()
                 .AddLogging();
 
-            serviceCollection.TryAdd(
+            services.TryAdd(
                 new ServiceDescriptor(
                     typeof(DbContextOptions<TContextImplementation>),
-                    p => DbContextOptionsFactory<TContextImplementation>(p, optionsAction, optionsBuilderFactory),
+                    p => optionsFunc(p),
                     optionsLifetime));
 
-            serviceCollection.Add(
+            services.Add(
                 new ServiceDescriptor(
                     typeof(DbContextOptions),
                     p => p.GetRequiredService<DbContextOptions<TContextImplementation>>(),
                     optionsLifetime));
+        }
+
+        private static void AddCoreServices<TContextImplementation>(
+            IServiceCollection services,
+            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            Func<DbContextOptionsBuilder<TContextImplementation>> dbContextBuilderFactory,
+            ServiceLifetime optionsLifetime)
+            where TContextImplementation : DbContext
+        {
+            AddCoreServices<TContextImplementation>(
+                services,
+                p => DbContextOptionsFactory(p, optionsAction, dbContextBuilderFactory),
+                optionsLifetime);
         }
 
         private static DbContextOptions<TContext> DbContextOptionsFactory<TContext>(

--- a/src/Tests/EFCore.DbContextFactory.IntegrationTest/EFCore.DbContextFactory.IntegrationTest.csproj
+++ b/src/Tests/EFCore.DbContextFactory.IntegrationTest/EFCore.DbContextFactory.IntegrationTest.csproj
@@ -22,6 +22,8 @@
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/src/Tests/EFCore.DbContextFactory.IntegrationTest/Startup.cs
+++ b/src/Tests/EFCore.DbContextFactory.IntegrationTest/Startup.cs
@@ -1,11 +1,14 @@
 ﻿using EFCore.DbContextFactory.Examples.Data.Persistence;
 using EFCore.DbContextFactory.Examples.Data.Repository;
+using EFCore.DbContextFactory.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using EFCore.DbContextFactory.Extensions;
+using System;
 
 namespace EFCore.DbContextFactory.IntegrationTest
 {
@@ -25,16 +28,17 @@ namespace EFCore.DbContextFactory.IntegrationTest
 
             services.AddDbContext<OrderContext>(builder =>
                 builder.UseInMemoryDatabase("OrdersExample"));
-            
-            services.AddDbContextFactory<OrderContext>(builder => builder
-                .UseInMemoryDatabase("OrdersExample"));
+
+            services.AddDbContextFactory<OrderContext>(
+                options => options.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning)),
+                () => SetupConnectionAndBuilderOptions<OrderContext>().ConfigureWarnings(warnings => warnings.Throw(RelationalEventId.MigrationAttributeMissingWarning)));
 
             services.AddScoped<OrderRepositoryWithFactory, OrderRepositoryWithFactory>();
             services.AddTransient<OrderRepository, OrderRepository>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IServiceProvider serviceProvider)
         {
             if (env.IsDevelopment())
             {
@@ -42,6 +46,28 @@ namespace EFCore.DbContextFactory.IntegrationTest
             }
 
             app.UseMvc();
+        }
+
+        /// <summary>
+        /// With thanks to:
+        /// https://www.scottbrady91.com/Entity-Framework/Entity-Framework-Core-In-Memory-Testing
+        /// https://github.com/JonPSmith/EfCore.TestSupport/blob/master/TestSupport/EfHelpers/SqliteInMemory.cs
+        /// </summary>
+        private static DbContextOptionsBuilder<T> SetupConnectionAndBuilderOptions<T>()
+            where T : DbContext
+        {
+            var connectionStringBuilder = new SqliteConnectionStringBuilder
+            {
+                DataSource = ":memory:"
+            };
+            var connectionString = connectionStringBuilder.ToString();
+            var connection = new SqliteConnection(connectionString);
+            connection.Open(); // See https://github.com/aspnet/EntityFramework/issues/6968
+
+            // Create an in-memory context
+            var builder = new DbContextOptionsBuilder<T>();
+            builder.UseSqlite(connection);
+            return builder;
         }
     }
 }


### PR DESCRIPTION
…tensions.

# Thank you for contributing to EF.DbContextFactory!

### The issue or feature being addressed

This small change allows one to pass an optional Options Builder Factory to the ServiceCollectionExtensions, rather than having to rely solely on the default DbContextOptionsBuilder.

### Details on the issue fix or feature implementation

None.

### Confirm the following

- [X]  I have merged the latest changes from the dev branch
- [X]  I have successfully run a local build
- [X]  I have included unit tests for the issue/feature (updated existing tests)
- [X]  I have targeted the PR against the latest dev branch
